### PR TITLE
Add barcode request length validation

### DIFF
--- a/backend/server.py
+++ b/backend/server.py
@@ -89,6 +89,8 @@ async def generate_barcode(request: BarcodeRequest):
         # Validate input
         if not request.text.strip():
             raise HTTPException(status_code=400, detail="Text cannot be empty")
+        if len(request.text) > 255:
+            raise HTTPException(status_code=400, detail="Text cannot exceed 255 characters")
         
         # Generate unique ID
         barcode_id = str(uuid.uuid4())

--- a/test_result.md
+++ b/test_result.md
@@ -149,6 +149,9 @@ backend:
       - working: true
         agent: "testing"
         comment: "✅ TESTED: All CRUD endpoints working perfectly. POST /api/generate-barcode creates barcodes with proper validation. GET /api/barcodes retrieves all barcodes. GET /api/barcode/{id} retrieves specific barcodes. DELETE /api/barcode/{id} removes barcodes. All endpoints handle errors correctly (404 for not found, 400 for invalid input)."
+      - working: true
+        agent: "main"
+        comment: "Added maximum length validation (255 chars) for barcode generation input and unit tests"
 
 frontend:
   - task: "Barcode Generator UI"
@@ -178,7 +181,7 @@ frontend:
 metadata:
   created_by: "main_agent"
   version: "1.0"
-  test_sequence: 1
+  test_sequence: 2
   run_ui: false
 
 test_plan:
@@ -192,3 +195,5 @@ agent_communication:
     message: "Implemented complete barcode generator app. Frontend tested manually and working. Backend needs thorough API testing for barcode generation, database storage, and CRUD operations."
   - agent: "testing"
     message: "✅ BACKEND TESTING COMPLETE: All backend APIs tested and working perfectly! Fixed one error handling bug where HTTPExceptions were being caught and re-raised as 500 errors. All 11 comprehensive tests passed (100% success rate). Tested: barcode generation (text/numbers/mixed), database storage, CRUD operations, error handling, and data persistence. Backend is production-ready."
+  - agent: "main"
+    message: "Added length validation to generate-barcode API and added unit tests verifying 400 response for inputs over 255 characters."

--- a/tests/test_text_length.py
+++ b/tests/test_text_length.py
@@ -1,0 +1,39 @@
+import sys
+import asyncio
+import pathlib
+import pytest
+
+# Add backend directory to path for importing server module
+backend_path = pathlib.Path(__file__).resolve().parent.parent / 'backend'
+sys.path.append(str(backend_path))
+
+import server  # type: ignore
+
+
+class DummyCollection:
+    async def insert_one(self, doc):
+        return None
+
+
+def patch_db(monkeypatch):
+    dummy_db = type('DummyDB', (), {'barcodes': DummyCollection()})()
+    monkeypatch.setattr(server, 'db', dummy_db)
+
+
+def test_generate_barcode_too_long(monkeypatch):
+    patch_db(monkeypatch)
+    long_text = 'a' * 256
+    request = server.BarcodeRequest(text=long_text)
+    with pytest.raises(server.HTTPException) as exc:
+        asyncio.run(server.generate_barcode(request))
+    assert exc.value.status_code == 400
+    assert '255' in exc.value.detail
+
+
+def test_generate_barcode_max_length(monkeypatch):
+    patch_db(monkeypatch)
+    monkeypatch.setattr(server, 'generate_barcode_image', lambda text: 'image')
+    valid_text = 'a' * 255
+    request = server.BarcodeRequest(text=valid_text)
+    response = asyncio.run(server.generate_barcode(request))
+    assert response.text == valid_text


### PR DESCRIPTION
## Summary
- enforce 255 character limit for barcode generation requests
- add unit tests for text length validation

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68c7d4f80b68832d870df99899aa49d5