### PR TITLE
Add manual dark mode toggle to QR gradient page

### DIFF
--- a/frontend/public/qrcode-gradient.html
+++ b/frontend/public/qrcode-gradient.html
@@ -1,0 +1,631 @@
+<!DOCTYPE html>
+<html lang="de">
+  <head>
+    <meta charset="UTF-8" />
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1.0, viewport-fit=cover"
+    />
+    <title>QR-Code Generator mit Farbverlauf</title>
+    <style>
+      *,
+      *::before,
+      *::after {
+        box-sizing: border-box;
+      }
+
+      :root,
+      :root[data-theme="light"] {
+        color-scheme: light;
+        font-family: "Inter", system-ui, -apple-system, BlinkMacSystemFont,
+          "Segoe UI", sans-serif;
+        --gradient-start: #4f46e5;
+        --gradient-end: #22d3ee;
+        --card-bg: rgba(255, 255, 255, 0.9);
+        --card-border: rgba(255, 255, 255, 0.45);
+        --text-primary: #0f172a;
+        --text-secondary: #475569;
+        --input-border: rgba(148, 163, 184, 0.6);
+        --input-bg: rgba(255, 255, 255, 0.85);
+        --button-gradient-start: #4338ca;
+        --button-gradient-end: #06b6d4;
+        --button-shadow: rgba(6, 182, 212, 0.32);
+        --link-button-bg: rgba(15, 23, 42, 0.08);
+        --link-button-hover: rgba(15, 23, 42, 0.12);
+        --preview-bg-start: rgba(255, 255, 255, 0.95);
+        --preview-bg-end: rgba(226, 232, 240, 0.65);
+        --preview-border: rgba(148, 163, 184, 0.3);
+        --qr-dark: #0f172a;
+        --qr-light: #ffffff;
+        --body-background: radial-gradient(
+            circle at top left,
+            rgba(255, 255, 255, 0.35),
+            transparent 55%
+          ),
+          radial-gradient(
+            circle at bottom right,
+            rgba(255, 255, 255, 0.4),
+            transparent 50%
+          ),
+          linear-gradient(135deg, var(--gradient-start), var(--gradient-end));
+      }
+
+      :root[data-theme="dark"] {
+        color-scheme: dark;
+        --gradient-start: #1d2671;
+        --gradient-end: #4c53ff;
+        --card-bg: rgba(15, 23, 42, 0.82);
+        --card-border: rgba(148, 163, 184, 0.18);
+        --text-primary: #e2e8f0;
+        --text-secondary: #cbd5f5;
+        --input-border: rgba(148, 163, 184, 0.45);
+        --input-bg: rgba(30, 41, 59, 0.85);
+        --button-gradient-start: #6366f1;
+        --button-gradient-end: #22d3ee;
+        --button-shadow: rgba(79, 70, 229, 0.32);
+        --link-button-bg: rgba(226, 232, 240, 0.12);
+        --link-button-hover: rgba(226, 232, 240, 0.2);
+        --preview-bg-start: rgba(30, 41, 59, 0.9);
+        --preview-bg-end: rgba(15, 23, 42, 0.8);
+        --preview-border: rgba(100, 116, 139, 0.35);
+        --qr-dark: #e2e8f0;
+        --qr-light: #0f172a;
+        --body-background: radial-gradient(
+            circle at top left,
+            rgba(99, 102, 241, 0.25),
+            transparent 55%
+          ),
+          radial-gradient(
+            circle at bottom right,
+            rgba(56, 189, 248, 0.2),
+            transparent 50%
+          ),
+          linear-gradient(135deg, var(--gradient-start), var(--gradient-end));
+      }
+
+      @media (prefers-color-scheme: dark) {
+        :root:not([data-theme]) {
+          color-scheme: dark;
+          --gradient-start: #1d2671;
+          --gradient-end: #4c53ff;
+          --card-bg: rgba(15, 23, 42, 0.82);
+          --card-border: rgba(148, 163, 184, 0.18);
+          --text-primary: #e2e8f0;
+          --text-secondary: #cbd5f5;
+          --input-border: rgba(148, 163, 184, 0.45);
+          --input-bg: rgba(30, 41, 59, 0.85);
+          --button-gradient-start: #6366f1;
+          --button-gradient-end: #22d3ee;
+          --button-shadow: rgba(79, 70, 229, 0.32);
+          --link-button-bg: rgba(226, 232, 240, 0.12);
+          --link-button-hover: rgba(226, 232, 240, 0.2);
+          --preview-bg-start: rgba(30, 41, 59, 0.9);
+          --preview-bg-end: rgba(15, 23, 42, 0.8);
+          --preview-border: rgba(100, 116, 139, 0.35);
+          --qr-dark: #e2e8f0;
+          --qr-light: #0f172a;
+          --body-background: radial-gradient(
+              circle at top left,
+              rgba(99, 102, 241, 0.25),
+              transparent 55%
+            ),
+            radial-gradient(
+              circle at bottom right,
+              rgba(56, 189, 248, 0.2),
+              transparent 50%
+            ),
+            linear-gradient(135deg, var(--gradient-start), var(--gradient-end));
+        }
+      }
+
+      body {
+        margin: 0;
+        min-height: 100vh;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        padding-top: max(2.5rem, 1.5rem + env(safe-area-inset-top));
+        padding-right: max(1.5rem, 1.25rem + env(safe-area-inset-right));
+        padding-bottom: max(2.5rem, 1.5rem + env(safe-area-inset-bottom));
+        padding-left: max(1.5rem, 1.25rem + env(safe-area-inset-left));
+        background: var(--body-background);
+        background-attachment: fixed;
+        color: var(--text-primary);
+      }
+
+      .card {
+        position: relative;
+        width: min(720px, 100%);
+        padding: clamp(1.75rem, 4vw, 3rem);
+        border-radius: 28px;
+        background: var(--card-bg);
+        border: 1px solid var(--card-border);
+        box-shadow: 0 28px 80px rgba(15, 23, 42, 0.2);
+        backdrop-filter: blur(12px);
+      }
+
+      .card::before {
+        content: "";
+        position: absolute;
+        inset: -1px;
+        z-index: -1;
+        border-radius: inherit;
+        background: linear-gradient(135deg, #ffffff, rgba(255, 255, 255, 0));
+        opacity: 0.35;
+      }
+
+      header {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: 1.25rem;
+        margin-bottom: 1.25rem;
+      }
+
+      h1 {
+        margin: 0;
+        font-size: clamp(2rem, 4vw, 2.8rem);
+        letter-spacing: -0.03em;
+      }
+
+      label {
+        display: block;
+        margin-bottom: 0.5rem;
+        font-weight: 600;
+        color: var(--text-primary);
+      }
+
+      input[type="text"] {
+        width: 100%;
+        padding: 0.85rem 1rem;
+        border-radius: 14px;
+        border: 1px solid var(--input-border);
+        background: var(--input-bg);
+        font-size: 1rem;
+        transition: border-color 0.2s ease, box-shadow 0.2s ease;
+      }
+
+      input[type="text"]:focus {
+        outline: none;
+        border-color: var(--gradient-start);
+        box-shadow: 0 0 0 4px rgba(79, 70, 229, 0.15);
+      }
+
+      button {
+        appearance: none;
+        border: none;
+        border-radius: 999px;
+        padding: 0.9rem 1.6rem;
+        font-weight: 600;
+        cursor: pointer;
+        background: linear-gradient(
+          135deg,
+          var(--button-gradient-start),
+          var(--button-gradient-end)
+        );
+        color: white;
+        transition: transform 0.2s ease, box-shadow 0.2s ease;
+        box-shadow: 0 18px 35px var(--button-shadow);
+      }
+
+      button:hover {
+        transform: translateY(-1px);
+        box-shadow: 0 20px 40px rgba(6, 182, 212, 0.4);
+      }
+
+      button:disabled {
+        cursor: not-allowed;
+        opacity: 0.65;
+        box-shadow: none;
+      }
+
+      .icon-button {
+        background: var(--link-button-bg);
+        color: var(--text-primary);
+        border-radius: 999px;
+        padding: 0.5rem 0.75rem;
+        display: inline-flex;
+        align-items: center;
+        gap: 0.4rem;
+        font-weight: 600;
+        transition: background 0.2s ease, color 0.2s ease;
+        box-shadow: none;
+        transform: none;
+      }
+
+      .icon-button:hover {
+        background: var(--link-button-hover);
+        box-shadow: none;
+        transform: none;
+      }
+
+      .icon-button svg {
+        width: 1.25rem;
+        height: 1.25rem;
+      }
+
+      .icon-button [data-theme-icon="moon"] {
+        display: none;
+      }
+
+      :root[data-theme="dark"] .icon-button [data-theme-icon="sun"],
+      :root:not([data-theme]) .icon-button[data-effective-theme="dark"]
+        [data-theme-icon="sun"] {
+        display: none;
+      }
+
+      :root[data-theme="dark"] .icon-button [data-theme-icon="moon"],
+      :root:not([data-theme]) .icon-button[data-effective-theme="dark"]
+        [data-theme-icon="moon"] {
+        display: inline;
+      }
+
+      .form-row {
+        display: grid;
+        gap: 1rem;
+        margin-bottom: 1.75rem;
+      }
+
+      .qr-preview {
+        position: relative;
+        border-radius: 24px;
+        padding: 1.5rem;
+        background: linear-gradient(
+          145deg,
+          var(--preview-bg-start),
+          var(--preview-bg-end)
+        );
+        border: 1px solid var(--preview-border);
+        display: grid;
+        place-items: center;
+        gap: 0.75rem;
+        min-height: 260px;
+      }
+
+      .qr-preview::before {
+        content: "";
+        position: absolute;
+        inset: 1.5rem;
+        border-radius: 18px;
+        background: conic-gradient(
+          from 180deg at 50% 50%,
+          rgba(79, 70, 229, 0.18),
+          rgba(14, 165, 233, 0.12),
+          rgba(79, 70, 229, 0.18)
+        );
+        z-index: 0;
+        filter: blur(12px);
+      }
+
+      #qrCanvas {
+        display: none;
+        position: relative;
+        z-index: 1;
+      }
+
+      .qr-preview[data-empty="false"] #qrCanvas {
+        display: block;
+      }
+
+      #qrCanvas canvas,
+      #qrCanvas img {
+        position: relative;
+        z-index: 1;
+        width: 220px;
+        height: 220px;
+      }
+
+      .actions {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 0.75rem;
+        align-items: center;
+        justify-content: space-between;
+        margin-top: 1.5rem;
+      }
+
+      .status {
+        color: var(--text-secondary);
+        font-size: 0.95rem;
+      }
+
+      .link-button {
+        background: var(--link-button-bg);
+        color: var(--text-primary);
+        padding: 0.75rem 1.2rem;
+        border-radius: 999px;
+        font-weight: 500;
+        text-decoration: none;
+        display: inline-flex;
+        align-items: center;
+        gap: 0.5rem;
+        transition: background 0.2s ease;
+      }
+
+      .link-button:hover {
+        background: var(--link-button-hover);
+      }
+
+      @media (max-width: 640px) {
+        .card {
+          border-radius: 24px;
+        }
+
+        .actions {
+          flex-direction: column;
+          align-items: stretch;
+        }
+
+        .actions button,
+        .actions .link-button {
+          width: 100%;
+          justify-content: center;
+        }
+      }
+
+      @media (max-width: 420px) {
+        body {
+          padding-top: max(1.75rem, 1.25rem + env(safe-area-inset-top));
+          padding-bottom: max(2rem, 1.25rem + env(safe-area-inset-bottom));
+        }
+
+        .card {
+          padding: clamp(1.5rem, 5vw, 2.25rem);
+        }
+
+        .qr-preview {
+          padding: 1.25rem;
+          min-height: 220px;
+        }
+
+        #qrCanvas canvas,
+        #qrCanvas img {
+          width: 190px;
+          height: 190px;
+        }
+      }
+    </style>
+  </head>
+  <body>
+    <div class="card" role="application">
+      <header>
+        <h1>QR-Code Generator</h1>
+        <button
+          type="button"
+          id="themeToggle"
+          class="icon-button"
+          aria-pressed="false"
+          aria-label="Darkmode umschalten"
+          title="Darkmode umschalten"
+        >
+          <svg
+            data-theme-icon="sun"
+            xmlns="http://www.w3.org/2000/svg"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="1.6"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            aria-hidden="true"
+          >
+            <circle cx="12" cy="12" r="4" />
+            <path
+              d="M12 2v2m0 16v2m10-10h-2M4 12H2m15.5 6.5-1.4-1.4M9.9 8.9 8.5 7.5m8.4-3.5-1.4 1.4M9.9 15.1l-1.4 1.4"
+            />
+          </svg>
+          <svg
+            data-theme-icon="moon"
+            xmlns="http://www.w3.org/2000/svg"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="1.6"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            aria-hidden="true"
+          >
+            <path d="M21 12.79A9 9 0 0 1 11.21 3 7 7 0 1 0 21 12.79Z" />
+          </svg>
+        </button>
+      </header>
+
+      <form id="qrForm" novalidate>
+        <div class="form-row">
+          <div>
+            <label for="qrInput">Text oder URL</label>
+            <input id="qrInput" type="text" name="qr" autocomplete="off" required />
+          </div>
+        </div>
+        <button type="submit" id="qrButton">QR-Code generieren</button>
+      </form>
+
+      <section aria-live="polite" aria-atomic="true">
+        <div id="qrContainer" class="qr-preview" data-empty="true">
+          <div id="qrCanvas" aria-hidden="true"></div>
+        </div>
+        <div class="actions">
+          <span id="qrStatus" class="status"></span>
+          <a
+            id="downloadLink"
+            class="link-button"
+            href="#"
+            download="qrcode.png"
+            hidden
+            ><span>QR-Code herunterladen</span></a
+          >
+        </div>
+      </section>
+    </div>
+
+    <script
+      src="https://cdnjs.cloudflare.com/ajax/libs/qrcodejs/1.0.0/qrcode.min.js"
+      integrity="sha512-H0jC8QqV9TnUQ5L4w1zcD3Ijn94Zmku4inHwZ6KsFGNymISupduFLB21F33iMZpETbOm3zszmfQdqg4InJGpGA=="
+      crossorigin="anonymous"
+      referrerpolicy="no-referrer"
+    ></script>
+    <script>
+      const form = document.getElementById("qrForm");
+      const input = document.getElementById("qrInput");
+      const button = document.getElementById("qrButton");
+      const container = document.getElementById("qrContainer");
+      const canvasHost = document.getElementById("qrCanvas");
+      const status = document.getElementById("qrStatus");
+      const downloadLink = document.getElementById("downloadLink");
+      const themeToggle = document.getElementById("themeToggle");
+
+      const themeStorageKey = "qr-theme";
+      const systemThemeQuery = "(prefers-color-scheme: dark)";
+
+      let qrCodeInstance = null;
+      let lastValue = "";
+
+      const getVar = (name, fallback) => {
+        const value = getComputedStyle(document.documentElement)
+          .getPropertyValue(name)
+          .trim();
+        return value || fallback;
+      };
+
+      const getQrSize = () =>
+        window.matchMedia("(max-width: 420px)").matches ? 200 : 220;
+
+      const createInstance = () =>
+        new QRCode(canvasHost, {
+          width: getQrSize(),
+          height: getQrSize(),
+          colorDark: getVar("--qr-dark", "#0f172a"),
+          colorLight: getVar("--qr-light", "#ffffff"),
+          correctLevel: QRCode.CorrectLevel.H,
+        });
+
+      const ensureInstance = () => {
+        if (!qrCodeInstance) {
+          qrCodeInstance = createInstance();
+        }
+      };
+
+      const updateDownloadLink = () => {
+        const canvas = canvasHost.querySelector("canvas");
+        if (!canvas) {
+          downloadLink.hidden = true;
+          return;
+        }
+        downloadLink.href = canvas.toDataURL("image/png");
+        downloadLink.hidden = false;
+      };
+
+      const regenerateWithLastValue = () => {
+        if (!lastValue) {
+          return;
+        }
+        qrCodeInstance?.clear();
+        canvasHost.innerHTML = "";
+        qrCodeInstance = createInstance();
+        qrCodeInstance.makeCode(lastValue);
+        container.dataset.empty = "false";
+        status.textContent = `QR-Code für "${lastValue}" aktualisiert.`;
+        updateDownloadLink();
+      };
+
+      const getEffectiveTheme = () =>
+        document.documentElement.getAttribute("data-theme") ||
+        (window.matchMedia(systemThemeQuery).matches ? "dark" : "light");
+
+      const reflectToggleState = () => {
+        const effectiveTheme = getEffectiveTheme();
+        themeToggle.dataset.effectiveTheme = effectiveTheme;
+        themeToggle.setAttribute("aria-pressed", String(effectiveTheme === "dark"));
+      };
+
+      const applyTheme = (theme) => {
+        if (theme) {
+          document.documentElement.setAttribute("data-theme", theme);
+        } else {
+          document.documentElement.removeAttribute("data-theme");
+        }
+        reflectToggleState();
+        regenerateWithLastValue();
+      };
+
+      const loadStoredTheme = () => {
+        const stored = localStorage.getItem(themeStorageKey);
+        if (stored === "light" || stored === "dark") {
+          applyTheme(stored);
+        } else {
+          applyTheme(null);
+        }
+      };
+
+      form.addEventListener("submit", (event) => {
+        event.preventDefault();
+        const value = input.value.trim();
+
+        if (!value) {
+          status.textContent = "Bitte Text oder URL eingeben.";
+          container.dataset.empty = "true";
+          lastValue = "";
+          qrCodeInstance?.clear();
+          canvasHost.innerHTML = "";
+          downloadLink.hidden = true;
+          return;
+        }
+
+        ensureInstance();
+        qrCodeInstance.clear();
+        canvasHost.innerHTML = "";
+        qrCodeInstance = createInstance();
+        qrCodeInstance.makeCode(value);
+
+        lastValue = value;
+        container.dataset.empty = "false";
+        status.textContent = `QR-Code für \"${value}\" erstellt.`;
+        updateDownloadLink();
+      });
+
+      input.addEventListener("input", () => {
+        button.disabled = !input.value.trim();
+      });
+
+      const watchMedia = (query, handler) => {
+        const media = window.matchMedia(query);
+        if (typeof media.addEventListener === "function") {
+          media.addEventListener("change", handler);
+        } else if (typeof media.addListener === "function") {
+          media.addListener(handler);
+        }
+        return media;
+      };
+
+      watchMedia(systemThemeQuery, () => {
+        if (!document.documentElement.hasAttribute("data-theme")) {
+          reflectToggleState();
+          regenerateWithLastValue();
+        }
+      });
+      watchMedia("(max-width: 420px)", regenerateWithLastValue);
+
+      status.textContent = "";
+      button.disabled = true;
+      loadStoredTheme();
+      reflectToggleState();
+
+      themeToggle.addEventListener("click", () => {
+        const nextTheme = getEffectiveTheme() === "dark" ? "light" : "dark";
+        localStorage.setItem(themeStorageKey, nextTheme);
+        applyTheme(nextTheme);
+      });
+
+      window.addEventListener("storage", (event) => {
+        if (event.key === themeStorageKey) {
+          const theme = event.newValue;
+          if (theme === "light" || theme === "dark") {
+            applyTheme(theme);
+          } else {
+            applyTheme(null);
+          }
+        }
+      });
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- restructure the gradient theme variables to support manual light and dark palettes
- add a header toggle with icon styling and persistence so users can switch dark mode explicitly
- refresh the form markup and QR regeneration script to remove the placeholder hint and react to theme changes

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_b_68e58a0d590c832db69777255163080f